### PR TITLE
Fixed multilingualism for sorting mode 4

### DIFF
--- a/system/drivers/DC_Multilingual.php
+++ b/system/drivers/DC_Multilingual.php
@@ -238,8 +238,16 @@ class DC_Multilingual extends DC_Table
 
 			if (!$objRow->numRows)
 			{
-				$blnIncludePid = ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4) ? true : false;
-				$intId = $this->Database->prepare("INSERT INTO " . $this->strTable . " ({$this->strPidColumn},tstamp,{$this->strLangColumn}" . ($blnIncludePid ? ",pid" : "") . ") VALUES (?,?,?" . ($blnIncludePid ? ",?" : "") . ")")->execute($this->intId, time(), $_SESSION['BE_DATA']['language'][$this->strTable][$this->intId], CURRENT_ID)->insertId;
+				// Save PID in sorting mode 4
+				if ($GLOBALS['TL_DCA'][$this->strTable]['list']['sorting']['mode'] == 4)
+				{
+					$intId = $this->Database->prepare("INSERT INTO " . $this->strTable . " ({$this->strPidColumn},tstamp,{$this->strLangColumn},pid) VALUES (?,?,?,?)")->execute($this->intId, time(), $_SESSION['BE_DATA']['language'][$this->strTable][$this->intId], CURRENT_ID)->insertId;					
+				}
+				else
+				{
+					$intId = $this->Database->prepare("INSERT INTO " . $this->strTable . " ({$this->strPidColumn},tstamp,{$this->strLangColumn}) VALUES (?,?,?)")->execute($this->intId, time(), $_SESSION['BE_DATA']['language'][$this->strTable][$this->intId])->insertId;
+				}
+
 				$objRow = $this->Database->prepare("SELECT * FROM " . $this->strTable . " WHERE id=?")->execute($intId);
 			}
 


### PR DESCRIPTION
Before, the pid was not set, which means it was saved in database as pid=0. When you have returned to list view of the child table, the Contao performed a table optimization basing on _ptable_ and _ctable_ values (delete all child records that have no parent). And the language record was deleted because it had pid set to 0.
