### PR TITLE
Fix for child-parent relationships

### DIFF
--- a/system/drivers/DC_Multilingual.php
+++ b/system/drivers/DC_Multilingual.php
@@ -238,8 +238,9 @@ class DC_Multilingual extends DC_Table
 
 			if (!$objRow->numRows)
 			{
-				// check if the table has a parent table defined, if so store the pid number
-				if ( strlen($GLOBALS['TL_DCA'][$this->strTable]['config']['ptable']) > 0 ) {
+				// check if the field 'pid' exists in the table, if so we should always store the pid idea as suggested in
+				// DC_Table#getNewPosition-method line 1130
+				if ($this->Database->fieldExists('pid', $this->strTable)) {
 					$intId = $this->Database->prepare("INSERT INTO " . $this->strTable . " ({$this->strPidColumn},tstamp,{$this->strLangColumn},pid) VALUES (?,?,?,?)")->execute($this->intId, time(), $_SESSION['BE_DATA']['language'][$this->strTable][$this->intId], CURRENT_ID)->insertId;
 				}
 				else


### PR DESCRIPTION
Currently DC_Multilingual only filled the pid column when the sorting mode was zero or 4. I think its better to check if the ptable configuration item is defined for the DCA table. For me this fixed it.
