### PR TITLE
BUGFIX: Problem mit Contao 3.2.3 Ajax Requests

### DIFF
--- a/config/autoload.ini
+++ b/config/autoload.ini
@@ -1,0 +1,19 @@
+;;
+; List modules which are required to be loaded beforehand
+;;
+requires[] = "core"
+
+;;
+; Configure what you want the autoload creator to register
+;;
+register_namespaces = true
+register_classes    = true
+register_templates  = true
+
+;;
+; Override the default configuration for certain sub directories
+;;
+[vendor/*]
+register_namespaces = false
+register_classes    = false
+register_templates  = false

--- a/config/autoload.php
+++ b/config/autoload.php
@@ -1,9 +1,13 @@
 <?php
 
 /**
- * @author  Kamil Kuzminski <kamil.kuzminski@codefog.pl>
- * @package DC_Multilingual
- * @license LGPL
+ * Contao Open Source CMS
+ *
+ * Copyright (c) 2005-2014 Leo Feyer
+ *
+ * @package Dc_multilingual
+ * @link    https://contao.org
+ * @license http://www.gnu.org/licenses/lgpl-3.0.html LGPL
  */
 
 
@@ -12,8 +16,13 @@
  */
 ClassLoader::addClasses(array
 (
-	'Contao\DC_Multilingual'       => 'system/modules/dc_multilingual/drivers/DC_Multilingual.php',
-	'Contao\MultilingualModel'     => 'system/modules/dc_multilingual/models/MultilingualModel.php',
+	// Classes
+	'Contao\DC_Multilingual_Query'    => 'system/modules/dc_multilingual/classes/DC_Multilingual_Query.php',
 	'Contao\MultilingualQueryBuilder' => 'system/modules/dc_multilingual/classes/MultilingualQueryBuilder.php',
-	'Contao\DC_Multilingual_Query' => 'system/modules/dc_multilingual/classes/DC_Multilingual_Query.php'
+
+	// Drivers
+	'DC_Multilingual'                 => 'system/modules/dc_multilingual/drivers/DC_Multilingual.php',
+
+	// Models
+	'Contao\MultilingualModel'        => 'system/modules/dc_multilingual/models/MultilingualModel.php',
 ));

--- a/drivers/DC_Multilingual.php
+++ b/drivers/DC_Multilingual.php
@@ -30,18 +30,6 @@
 
 
 /**
- * Run in a custom namespace so the class can be replaced
- */
-namespace Contao;
-
-
-/**
- * Require the DC_Table driver
- */
-require_once(TL_ROOT . '/system/modules/core/drivers/DC_Table.php');
-
-
-/**
  * Class DC_Multilingual
  *
  * Provide methods to handle multilingual DC_Table entries
@@ -51,7 +39,7 @@ require_once(TL_ROOT . '/system/modules/core/drivers/DC_Table.php');
  * @author     Kamil Kuzminski <kamil.kuzminski@codefog.pl>
  * @package    dc_multilingual
  */
-class DC_Multilingual extends DC_Table
+class DC_Multilingual extends \DC_Table
 {
 
 	/**


### PR DESCRIPTION
Ich hatte Probleme bei sämtlichen Ajax Requests.
Wenn die Klasse DC_Multilingual im namespace Contao liegt und somit von \Contao\DC_Table extended bricht der Request bei folgendem Check ab.

https://github.com/contao/core/blob/master/system/modules/core/classes/Ajax.php#L209
