### PR TITLE
Use table name as prefix instead of t1 

### DIFF
--- a/src/Model/Multilingual.php
+++ b/src/Model/Multilingual.php
@@ -89,9 +89,10 @@ class Multilingual extends \Model
      */
     public static function findByAlias($alias, $aliasColumnName = 'alias', $options = [])
     {
+        $table   = static::getTable();
         $options = array_merge([
                 'limit' => 1,
-                'column' => ["(t1.$aliasColumnName=?"],
+                'column' => ["($table.$aliasColumnName=?"],
                 'value' => [$alias],
                 'return' => 'Model',
             ],
@@ -112,9 +113,10 @@ class Multilingual extends \Model
      */
     public static function findByMultilingualAlias($alias, $aliasColumnName = 'alias', $options = [])
     {
+        $table   = static::getTable();
         $options = array_merge([
                 'limit' => 1,
-                'column' => ["(t1.$aliasColumnName=? OR t2.$aliasColumnName=?)"],
+                'column' => ["($table.$aliasColumnName=? OR t2.$aliasColumnName=?)"],
                 'value' => [$alias, $alias],
                 'return' => 'Model',
             ],
@@ -226,8 +228,9 @@ class Multilingual extends \Model
                     $qb->andWhere($column);
                 }
             } else {
-                // Default is likely t1
-                $qb->andWhere('t1.'.$options['column'].'=?');
+                // Default is likely fallback table
+                $table = static::getTable();
+                $qb->andWhere("$table.{$options['column']}=?");
             }
         }
 

--- a/src/QueryBuilder/MultilingualQueryBuilder.php
+++ b/src/QueryBuilder/MultilingualQueryBuilder.php
@@ -78,9 +78,9 @@ class MultilingualQueryBuilder implements MultilingualQueryBuilderInterface
     {
         $this->qb->resetQueryParts();
 
-        $this->qb->addSelect('COUNT(t1.id) AS count')
-            ->from($this->table, 't1')
-            ->where("t1.{$this->pidColumnName}=0");
+        $this->qb->addSelect("COUNT({$this->table}.id) AS count")
+            ->from($this->table, $this->table)
+            ->where("{$this->table}.{$this->pidColumnName}=0");
     }
 
     /**
@@ -94,25 +94,25 @@ class MultilingualQueryBuilder implements MultilingualQueryBuilderInterface
 
         // Regular fields
         foreach ($this->regularFields as $field) {
-            $this->qb->addSelect("t1.$field");
+            $this->qb->addSelect("{$this->table}.$field");
         }
 
         // Translatable fields
         foreach ($this->translatableFields as $field) {
-            $this->qb->addSelect("IFNULL(t2.$field, t1.$field) AS $field");
+            $this->qb->addSelect("IFNULL(t2.$field, {$this->table}.$field) AS $field");
         }
 
-        $this->qb->from($this->table, 't1');
+        $this->qb->from($this->table, $this->table);
         $this->qb->add('join', [
-            't1' => [
+            $this->table => [
                 'joinType' => 'left outer',
                 'joinTable' => $this->table,
                 'joinAlias' => 't2',
-                'joinCondition' => "t1.id=t2.{$this->pidColumnName} AND t2.{$this->langColumnName}='$language'",
+                'joinCondition' => "{$this->table}.id=t2.{$this->pidColumnName} AND t2.{$this->langColumnName}='$language'",
             ],
         ], true);
 
-        $this->qb->where("t1.{$this->pidColumnName}=0");
+        $this->qb->where("{$this->table}.{$this->pidColumnName}=0");
     }
 
     /**


### PR DESCRIPTION
Use table name as prefix instead of t1 to avoid issues with custom queries (See #42).