### PR TITLE
fix typo in findByAlias

### DIFF
--- a/src/Model/Multilingual.php
+++ b/src/Model/Multilingual.php
@@ -91,7 +91,7 @@ class Multilingual extends \Model
     {
         $options = array_merge([
                 'limit' => 1,
-                'column' => ["(t1.$aliasColumnName=?"],
+                'column' => ["t1.$aliasColumnName=?"],
                 'value' => [$alias],
                 'return' => 'Model',
             ],


### PR DESCRIPTION
The typo results in queries like
```
… AND ((t1.alias='…') LIMIT 0
```
which is of course wrong syntax due to the superfluous opening bracket and results in an error.