### PR TITLE
fix language column name

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ $GLOBALS['TL_DCA']['table']['config']['dataContainer'] = 'Multilingual';
 $GLOBALS['TL_DCA']['table']['config']['languages'] = ['en', 'de', 'pl'];
 
 // Database column that contains the language keys (default: "language")
-$GLOBALS['TL_DCA']['table']['config']['langColumnName'] = 'language';
+$GLOBALS['TL_DCA']['table']['config']['langColumn'] = 'language';
 
 // Database column that contains the reference id (default: "langPid")
 $GLOBALS['TL_DCA']['table']['config']['langPid'] = 'langPid';


### PR DESCRIPTION
The actual config field for the language column is `langColumn`, not `langColumnName`:

https://github.com/terminal42/contao-DC_Multilingual/blob/56c0fbd77277dd840fc043645d37c6e9c6e799df/src/Model/Multilingual.php#L127-L141