### PR TITLE
fix lang column name retrieval

### DIFF
--- a/src/Model/Multilingual.php
+++ b/src/Model/Multilingual.php
@@ -133,8 +133,8 @@ class Multilingual extends \Model
     {
         static::ensureDataContainerIsLoaded();
 
-        if ($GLOBALS['TL_DCA'][static::getTable()]['config']['langColumn']) {
-            return $GLOBALS['TL_DCA'][static::getTable()]['config']['langColumn'];
+        if ($GLOBALS['TL_DCA'][static::getTable()]['config']['langColumnName']) {
+            return $GLOBALS['TL_DCA'][static::getTable()]['config']['langColumnName'];
         }
 
         return 'language';


### PR DESCRIPTION
The `DC_Multilingual` uses `langColumnName` - however, the `Multilingual::getLangColumn` function erroneously uses `langColumn` instead.

This probably went under the radar so far, since in most cases the default name `language` will be used. However, for tables that already contain a field called `language`, you need to set this to a different value.

See also https://github.com/terminal42/contao-DC_Multilingual/pull/54#issuecomment-495265900