### PR TITLE
Fix ClassNotFoundException

### DIFF
--- a/src/Model/Multilingual.php
+++ b/src/Model/Multilingual.php
@@ -12,10 +12,11 @@
 namespace Terminal42\DcMultilingualBundle\Model;
 
 use Contao\Database;
+use Contao\Model;
 use Doctrine\DBAL\Query\QueryBuilder;
 use Terminal42\DcMultilingualBundle\QueryBuilder\MultilingualQueryBuilderFactoryInterface;
 
-class Multilingual extends \Model
+class Multilingual extends Model
 {
     /**
      * Prevent the model from saving.


### PR DESCRIPTION
Fixes issue with class loading:

```
ClassNotFoundException
Attempted to load class "Model" from the global namespace.
Did you forget a "use" statement?

in Multilingual.php line 18
--
at include()in DebugClassLoader.php line 159
at DebugClassLoader->loadClass('Terminal42\\DcMultilingualBundle\\Model\\Multilingual')
at spl_autoload_call('Terminal42\\DcMultilingualBundle\\Model\\Multilingual')in ContactModel.php line 10
```

My model looks like this:
```php
<?php

declare(strict_types=1);

namespace App\Model;

use Terminal42\DcMultilingualBundle\Model\Multilingual;

class ContactModel extends Multilingual
{
	// ... 
}
```