### PR TITLE
Id, language pid and language column not translated

### DIFF
--- a/src/Model/Multilingual.php
+++ b/src/Model/Multilingual.php
@@ -52,7 +52,7 @@ class Multilingual extends Model
         }
 
         // Try to load the translated model
-        $translatedModel = static::findByPk($this->id, ['language' => $language]);
+        $translatedModel = static::findByPk($this->getLanguageId(), ['language' => $language]);
 
         if (null === $translatedModel) {
             // Get fallback
@@ -62,7 +62,7 @@ class Multilingual extends Model
                 return $this->{$aliasColumnName};
             }
 
-            $fallbackModel = static::findByPk($this->id, ['language' => $fallbackLang]);
+            $fallbackModel = static::findByPk($this->getLanguageId(), ['language' => $fallbackLang]);
 
             return $fallbackModel->{$aliasColumnName};
         }

--- a/src/QueryBuilder/MultilingualQueryBuilder.php
+++ b/src/QueryBuilder/MultilingualQueryBuilder.php
@@ -12,6 +12,7 @@
 namespace Terminal42\DcMultilingualBundle\QueryBuilder;
 
 use Doctrine\DBAL\Query\QueryBuilder;
+use function array_intersect;
 
 class MultilingualQueryBuilder implements MultilingualQueryBuilderInterface
 {
@@ -107,8 +108,14 @@ class MultilingualQueryBuilder implements MultilingualQueryBuilderInterface
     {
         $this->qb->resetQueryParts();
 
+        // Always translate system columns
+        $systemColumns = ['id', $this->langColumnName, $this->pidColumnName];
+        foreach ($systemColumns as $field) {
+            $this->qb->addSelect("IFNULL(translation.$field, {$this->table}.$field) AS $field");
+        }
+
         // Regular fields
-        foreach (array_diff($this->regularFields, $this->translatableFields) as $field) {
+        foreach (array_diff($this->regularFields, $this->translatableFields, $systemColumns) as $field) {
             $this->qb->addSelect("{$this->table}.$field");
         }
 


### PR DESCRIPTION
Right now the `id`, `langPid` and `langColumn` doesn't get translated by default which causes several issues:

 - It's not possible to determinate the language from an loaded model
 - It's not possible to determinate the real id of an loaded model
 - Saving a loaded model would override the fallback language

So this pull request always handles such columns as translated columns.

Furthermore it addresses an issue in the `getAlias` method which uses the actual id and not `getLanguageId()`.