### PR TITLE
Fix copy translation

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -604,9 +604,15 @@ class Driver extends \DC_Table
             $set = $this->set;
 
             foreach ($objTranslations->row() as $k => $v) {
-                if (in_array($k, array_keys($GLOBALS['TL_DCA'][$this->strTable]['fields']))
-                    && $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['translatableFor'] != ''
-                ) {
+                if (array_key_exists($k, $GLOBALS['TL_DCA'][$this->strTable]['fields'])) {
+                    if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['translatableFor'] == '') {
+                        if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default'])) {
+                            $set[$k] = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default'];
+                        } else {
+                            unset($set[$k]);
+                        }
+                        continue;
+                    }
                     // Empty unique fields or add a unique identifier in copyAll mode
                     if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['unique']) {
                         if (\Input::get('act') == 'copyAll') {

--- a/src/Driver.php
+++ b/src/Driver.php
@@ -605,7 +605,7 @@ class Driver extends \DC_Table
 
             foreach ($objTranslations->row() as $k => $v) {
                 if (array_key_exists($k, $GLOBALS['TL_DCA'][$this->strTable]['fields'])) {
-                    if ($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['translatableFor'] == '') {
+                    if (!$GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['eval']['translatableFor']) {
                         if (isset($GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default'])) {
                             $set[$k] = $GLOBALS['TL_DCA'][$this->strTable]['fields'][$k]['default'];
                         } else {


### PR DESCRIPTION
Non translated fields may not use values of fallback language when creating a copy. Instead the defined default value should be used. Use default value defined in the dca or the sql default instead.

**Example**

A data set has an translatable title. The category isn't translatable but assigned in the fallback language.

Given:

| id | *title*    | categoryId | lang_pid | language |
|----|----------|------------|----------|----------|
| 1  | Beispiel | 2          | 0        |          |
| 2  | Example  | 0          | 1        | en       |
| 3  | Exemple  | 0          | 1        | fr       |

Expected result after copy:

| id | *title*    | categoryId | lang_pid | language |
|----|----------|------------|----------|----------|
| 1  | Beispiel | 2          | 0        |          |
| 2  | Example  | 0          | 1        | en       |
| 3  | Exemple  | 0          | 1        | fr       |
| 4  | Beispiel | 2          | 0        |          |
| 5  | Example  | 0          | 4        | en       |
| 6  | Exemple  | 0          | 4        | fr       |

Current behaviour:

Each translation uses the value of fallback language. If I change the category now, it does not effect the translations as they still reference to the old value.

| id | *title*    | categoryId | lang_pid | language |
|----|----------|------------|----------|----------|
| 1  | Beispiel | 2          | 0        |          |
| 2  | Example  | 0          | 1        | en       |
| 3  | Exemple  | 0          | 1        | fr       |
| 4  | Beispiel | 2          | 0        |          |
| 5  | Example  | 2          | 4        | en       |
| 6  | Exemple  | 2          | 4        | fr       |





