### PR TITLE
Prevent direct access to a translated record

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -145,8 +145,17 @@ class Driver extends \DC_Table
             ->limit(1)
             ->execute($this->intId);
 
-        // Redirect if there is no record with the given ID
-        if ($objRow->numRows < 1)
+        // Access to a translation detected, redirect with main language id and request translated version
+        if ($objRow->{$this->pidColumnName} > 0)
+        {
+            $this->sessionKey = 'dc_multilingual:' . $this->strTable . ':' . $objRow->{$this->pidColumnName};
+            $objSessionBag = \System::getContainer()->get('session')->getBag('contao_backend');
+            $objSessionBag->set($this->sessionKey, $objRow->{$this->langColumnName});
+            $this->redirect($this->addToUrl('id=' . $objRow->{$this->pidColumnName}));
+        }
+
+        // Deny access if there is no record with the given ID or a translated version is accessed
+        if ($objRow->numRows < 1 || $objRow->{$this->pidColumnName} > 0)
         {
             throw new AccessDeniedException('Cannot load record "' . $this->strTable . '.id=' . $this->intId . '".');
         }


### PR DESCRIPTION
I have an advanced setup there the DC_Multilingual is used for the table `exmaple`. Furthermore the table uses the `tl_content` as child table. To achieve translations the content elements are bound to the translated version of the `example` table. 

This works pretty well but also unveiled a missing protection in the DC_Multilingual which causes broken translations.

When I'm in a translated parent view the edit button in the header contains the `ID` of the translated version. The DC_Multilingual does not detect that it's a translated version and threats it as root language. Then I create a new translation now, the new transition is bound to another translation.

This pull request denies direct access to such a record. Futhermore it does a redirect to the correct link and updates the session key to get the requested translation of a record.