### PR TITLE
Do not translate the main record ID

### DIFF
--- a/src/QueryBuilder/MultilingualQueryBuilder.php
+++ b/src/QueryBuilder/MultilingualQueryBuilder.php
@@ -12,7 +12,6 @@
 namespace Terminal42\DcMultilingualBundle\QueryBuilder;
 
 use Doctrine\DBAL\Query\QueryBuilder;
-use function array_intersect;
 
 class MultilingualQueryBuilder implements MultilingualQueryBuilderInterface
 {
@@ -108,10 +107,15 @@ class MultilingualQueryBuilder implements MultilingualQueryBuilderInterface
     {
         $this->qb->resetQueryParts();
 
+        $systemColumns = [
+            'id' => 'translationId',
+            $this->langColumnName => $this->langColumnName,
+            $this->pidColumnName => $this->pidColumnName,
+        ];
+
         // Always translate system columns
-        $systemColumns = ['id', $this->langColumnName, $this->pidColumnName];
-        foreach ($systemColumns as $field) {
-            $this->qb->addSelect("IFNULL(translation.$field, {$this->table}.$field) AS $field");
+        foreach ($systemColumns as $field => $name) {
+            $this->qb->addSelect("IFNULL(translation.$field, {$this->table}.$field) AS $name");
         }
 
         // Regular fields


### PR DESCRIPTION
As suggested in https://github.com/terminal42/contao-DC_Multilingual/issues/69, this fixes the issue of a translated model ID. Translating the model ID is likely to cause downstream issues e.g. if someone uses `$GLOBALS['TL_MODEL']` without knowning of DC_Multilingual.

The existing `MultilingualTrait::getLanguageId()` should continue to work, as the `langPid` is still present (but possibly the same as `id`).

The only possible issue would arise if someone **expects `$model->id` to be the translated record ID**, but I cannot imagine why that would ever make sense.

/cc @Defcon0 @dmolineus 