### PR TITLE
Fix retrieving custom column name

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -105,8 +105,8 @@ class Driver extends \DC_Table
         $this->sessionKey = 'dc_multilingual:' . $this->strTable . ':' . $this->intId;
 
         // Column names
-        $this->pidColumnName = isset($dca['config']['langPid']) ?: 'langPid';
-        $this->langColumnName = isset($dca['config']['langColumnName']) ?: 'language';
+        $this->pidColumnName = isset($dca['config']['langPid']) ? $dca['config']['langPid'] : 'langPid';
+        $this->langColumnName = isset($dca['config']['langColumnName']) ? $dca['config']['langColumnName'] : 'language';
 
         // Filter out translations
         if ($dca['list']['sorting']['mode'] !== 5 && $dca['list']['sorting']['mode'] !== 6) {


### PR DESCRIPTION
Since https://github.com/terminal42/contao-DC_Multilingual/commit/d816b38f485261e0c6a676f7adc83f7c602af6a1 the column name are broken if a custom column name is used.