### PR TITLE
Fix versioning of language variants

### DIFF
--- a/src/Driver.php
+++ b/src/Driver.php
@@ -164,7 +164,20 @@ class Driver extends \DC_Table
         $this->procedure[] = 'id=?';
 
         $this->blnCreateNewVersion = false;
-        $objVersions = new \Versions($this->strTable, $this->intId);
+
+        // Handle language change or deletion
+        $this->handleLanguageOperation();
+
+        // Load the language record
+        $this->loadCurrentLanguageRecord();
+
+        $versionId = $this->intId;
+
+        if ($this->objActiveRecord && $this->objActiveRecord->id) {
+            $versionId = $this->objActiveRecord->id;
+        }
+
+        $objVersions = new \Versions($this->strTable, $versionId);
 
         if (!($GLOBALS['TL_DCA'][$this->strTable]['config']['hideVersionMenu'] ?? false)) {
             // Compare versions
@@ -185,12 +198,6 @@ class Driver extends \DC_Table
                 $this->reload();
             }
         }
-
-        // Handle language change or deletion
-        $this->handleLanguageOperation();
-
-        // Load the language record
-        $this->loadCurrentLanguageRecord();
 
         $objVersions->initialize();
 


### PR DESCRIPTION
To fix the versioning of language variants the order of some methods needs to be changed and the versionID has to be set correctly.

Although the direct jump with the version `editURL` from the starting page wont work at all.
In our private fork we extended the logic for `Access to a translation detected`.
I was not sure if you want this in the extension but if you like I could add another PR.
