### PR TITLE
Correct incorrect table alias in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ class NewsModel extends Terminal42\DcMultilingualBundle\Model\Multilingual
 
     public static function findPublished()
     {
-        return static::findBy(['t1.published=?'], [1]);
+        return static::findBy(['tl_news.published=?'], [1]);
     }
 }
 ```


### PR DESCRIPTION
According to [this comment](https://github.com/terminal42/contao-DC_Multilingual/issues/59#issuecomment-558885449) version 4 does not use t1 as the table alias in queries anymore but the actual table name. The README still provides an example with t1. This took me a while to figure out... 😅 